### PR TITLE
fix Http Sink Plugin url and requestHeaders macro bug

### DIFF
--- a/src/main/java/io/cdap/plugin/http/sink/batch/HTTPSinkConfig.java
+++ b/src/main/java/io/cdap/plugin/http/sink/batch/HTTPSinkConfig.java
@@ -273,7 +273,9 @@ public class HTTPSinkConfig extends ReferencePluginConfig {
 
   public void validate(FailureCollector collector) {
     try {
-      new URL(url);
+      if (!containsMacro(URL)) {
+        new URL(url);
+      }
     } catch (MalformedURLException e) {
       collector.addFailure(String.format("URL '%s' is malformed: %s", url, e.getMessage()), null)
         .withConfigProperty(URL);
@@ -285,7 +287,9 @@ public class HTTPSinkConfig extends ReferencePluginConfig {
     }
 
     try {
-      convertHeadersToMap(requestHeaders);
+      if (!containsMacro(REQUEST_HEADERS)) {
+        convertHeadersToMap(requestHeaders);
+      }
     } catch (IllegalArgumentException e) {
       collector.addFailure(e.getMessage(), null)
         .withConfigProperty(REQUEST_HEADERS);


### PR DESCRIPTION
When using macro for url argument will unable to pass validation and unable to deploy pipeline.

How to fix:
Update validation function and add `containsMacro` check.