### PR TITLE
add liveramp plugins project as parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,12 @@
   <artifactId>http-plugins-lr</artifactId>
   <version>1.0.0</version>
 
+  <parent>
+    <groupId>com.liveramp.cdap</groupId>
+    <artifactId>liveramp_cdap</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
@@ -584,7 +590,7 @@
           <author>LiveRamp</author>
           <org>LiveRamp</org>
           <!-- Using directory maven plugin        -->
-          <relativeOutputDir>./packages</relativeOutputDir>
+          <relativeOutputDir>${cdap-plugins.basedir}/packages</relativeOutputDir>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
In order to build this project in liveramp_plugins project as submodule, it needs to add liveramp_plugins as parent.